### PR TITLE
Ignore removed testFreestyleJobRemoteTriggering()

### DIFF
--- a/src/test/java/school/redrover/JobRemoteTriggeringAJTest.java
+++ b/src/test/java/school/redrover/JobRemoteTriggeringAJTest.java
@@ -97,7 +97,6 @@ public class JobRemoteTriggeringAJTest extends BaseTest {
         getDriver().switchTo().window(tabs.get(0));
     }
 
-    @Ignore
     @Test
     public void testFreestyleJobRemoteTriggering() {
         final String projectName = "Project1";

--- a/src/test/java/school/redrover/JobRemoteTriggeringAJTest.java
+++ b/src/test/java/school/redrover/JobRemoteTriggeringAJTest.java
@@ -113,8 +113,13 @@ public class JobRemoteTriggeringAJTest extends BaseTest {
 
         triggerJobViaHTTPRequest(token, user, projectName);
 
-        getWait60().until(ExpectedConditions.elementToBeClickable(By.xpath("//a[@tooltip='Success > Console Output']")))
-                .click();
+        int count = 0;
+        while(getDriver().findElements(By.xpath("//a[@tooltip='Success > Console Output']")).isEmpty()
+                && count < 2){
+            getWait60().until(ExpectedConditions.elementToBeClickable(By.xpath("//a[@tooltip='Success > Console Output']")));
+            count++;
+        }
+        getWait60().until(ExpectedConditions.elementToBeClickable(By.xpath("//a[@tooltip='Success > Console Output']"))).click();
 
         final String actualConsoleLogs = getWait5().until(ExpectedConditions.visibilityOfElementLocated(By.className("console-output")))
                 .getText();


### PR DESCRIPTION
Ignore removed testFreestyleJobRemoteTriggering()

testFreestyleJobRemoteTriggering(school.redrover.JobRemoteTriggeringAJTest)  Time elapsed: 62.573 sec  <<< FAILURE!
8647
org.openqa.selenium.TimeoutException: Expected condition failed: waiting for element to be clickable: By.xpath: //a[@tooltip='Success > Console Output'] (tried for 60 second(s) with 500 milliseconds interval)